### PR TITLE
Add Travis CI setting and fix install instruction on README

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: python
+
+dist: bionic
+
+python:
+  - 3.6
+
+install:
+  - pip install -e .
+
+script:
+  # This repository has NOT had tests
+  # but Travis CI wouldn't allow us not to write
+  # `script` so we run this meaning less command to avoid CI errors.
+  - echo "TODO"

--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ The key ideas of quantum machine learning and quantum walk are [here](https://qw
 
 ## How to install
 
-**This installation might not work properly.**
-
 First, clone remote repository to your local.
 
 `git clone https://github.com/qwqmlf/qwgc.git`
@@ -22,7 +20,7 @@ and then,
 
 ```zsh
 cd qwgc
-pip install .
+pip install -e .
 ```
 
 If you don't have any errors, your build is success.
@@ -32,7 +30,12 @@ If you don't have any errors, your build is success.
 [experiments.toml](https://github.com/qwqmlf/qwgc/blob/master/qwgc/experiments.toml) is the configuration (Hyper parameter) for QWGC.
 
 Put hyper parameters and then run
-`python QWGC.py`  
+
+```zsh
+cd qwgc
+python QWGC.py
+```
+
 (This simulation may take a long time to finish)
 
 ## Tutorials


### PR DESCRIPTION
- Add [Travis CI](https://travis-ci.org) setting
    - https://travis-ci.org/y-yu/qwgc/builds/647939695#L2 👈my example result
- Fix install instruction in `README.md`
    - You wrote `pip install .` but it would make us install this software from [PyPI](https://pypi.org/project/pip/)
        - FYI: https://pip.pypa.io/en/stable/reference/pip_install/#cmdoption-e
    - If `-e` option would be used `pip` install the software from `setup.py` on the current directory
    - I think it would be better way to install after `git clone`
- Since above Travis CI succeeded so I drop `This installation might not work properly` off